### PR TITLE
feat: 收录酷我/咪咕/酷狗/汽水音源插件

### DIFF
--- a/player-core/src/main/resources/dev/t1m3/qplayer/plugin/plugin-catalog.json
+++ b/player-core/src/main/resources/dev/t1m3/qplayer/plugin/plugin-catalog.json
@@ -12,5 +12,33 @@
     "description": "由独立项目维护的 QQ 音乐音源插件，提供搜索、播放、歌词与 Cookie 登录。",
     "repo": "TIMER-err/qplayer-qqmusic-plugin",
     "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED7z1yYQ9a5UVpOPUict1ShkKH26NnbEMMAHsxy5zJEPeDd3J2etP1PRKXylO2KWWZgib2KB5/yZ0Xgmj+36TBg=="
+  },
+  {
+    "id": "kuwo",
+    "name": "酷我音乐",
+    "description": "由独立项目维护的酷我音乐音源插件，提供搜索、播放、歌词与 Cookie 登录。",
+    "repo": "MiaM1ku/qplayer-kuwo-plugin",
+    "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
+  },
+  {
+    "id": "migu",
+    "name": "咪咕音乐",
+    "description": "由独立项目维护的咪咕音乐音源插件，提供搜索、播放、歌词与 Cookie 登录。",
+    "repo": "MiaM1ku/qplayer-migu-plugin",
+    "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
+  },
+  {
+    "id": "kugou",
+    "name": "酷狗音乐",
+    "description": "由独立项目维护的酷狗音乐音源插件，提供搜索、播放、歌词、扫码登录与用户歌单。",
+    "repo": "MiaM1ku/qplayer-kugou-plugin",
+    "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
+  },
+  {
+    "id": "soda",
+    "name": "汽水音乐",
+    "description": "由独立项目维护的汽水音乐音源插件，提供搜索、播放、歌词、扫码登录与用户歌单。",
+    "repo": "MiaM1ku/qplayer-soda-plugin",
+    "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
   }
 ]

--- a/player-core/src/test/java/dev/t1m3/qplayer/plugin/PluginCatalogServiceTest.java
+++ b/player-core/src/test/java/dev/t1m3/qplayer/plugin/PluginCatalogServiceTest.java
@@ -33,7 +33,7 @@ public class PluginCatalogServiceTest {
 
     @Test public void pinnedSourcesCarryAValidIdAndPublisherKey() throws Exception {
         List<PluginCatalogService.Source> sources = PluginCatalogService.loadBundledSources();
-        assertEquals(2, sources.size());
+        assertEquals(6, sources.size());
         Set<String> ids = new HashSet<>();
         for (PluginCatalogService.Source source : sources) {
             dev.t1m3.qplayer.media.MediaId.validateProvider(source.id);
@@ -44,6 +44,10 @@ public class PluginCatalogServiceTest {
         }
         assertTrue(ids.contains("netease"));
         assertTrue(ids.contains("qq"));
+        assertTrue(ids.contains("kuwo"));
+        assertTrue(ids.contains("migu"));
+        assertTrue(ids.contains("kugou"));
+        assertTrue(ids.contains("soda"));
     }
 
     @Test public void latestReleaseFallsBackToTheNextCandidateAndPicksTheQplugAsset()


### PR DESCRIPTION
## 说明

向 `plugin-catalog.json` 增加四个由 [MiaM1ku](https://github.com/MiaM1ku) 维护的独立音源插件，命名与现有 `qplayer-netease-plugin` / `qplayer-qqmusic-plugin` 一致。

| id | 仓库 | latest |
|---|---|---|
| kuwo | [MiaM1ku/qplayer-kuwo-plugin](https://github.com/MiaM1ku/qplayer-kuwo-plugin) | [v0.1.0](https://github.com/MiaM1ku/qplayer-kuwo-plugin/releases/tag/v0.1.0) |
| migu | [MiaM1ku/qplayer-migu-plugin](https://github.com/MiaM1ku/qplayer-migu-plugin) | [v0.1.0](https://github.com/MiaM1ku/qplayer-migu-plugin/releases/tag/v0.1.0) |
| kugou | [MiaM1ku/qplayer-kugou-plugin](https://github.com/MiaM1ku/qplayer-kugou-plugin) | [v0.1.0](https://github.com/MiaM1ku/qplayer-kugou-plugin/releases/tag/v0.1.0) |
| soda | [MiaM1ku/qplayer-soda-plugin](https://github.com/MiaM1ku/qplayer-soda-plugin) | [v0.1.0](https://github.com/MiaM1ku/qplayer-soda-plugin/releases/tag/v0.1.0) |

四个仓库共用同一把 P-256 发布者密钥（`publisher-key.pub`），Release 由 tag `v0.1.0` 触发 CI 签名后挂载唯一 `.qplug`。

`PluginCatalogServiceTest` 已同步期望的目录条目数量与 id。