### PR TITLE
feat: 收录 Apple Music 音源插件

### DIFF
--- a/player-core/src/main/resources/dev/t1m3/qplayer/plugin/plugin-catalog.json
+++ b/player-core/src/main/resources/dev/t1m3/qplayer/plugin/plugin-catalog.json
@@ -40,5 +40,12 @@
     "description": "由独立项目维护的汽水音乐音源插件，提供搜索、播放、歌词、扫码登录与用户歌单。",
     "repo": "MiaM1ku/qplayer-soda-plugin",
     "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
+  },
+  {
+    "id": "apple",
+    "name": "Apple Music",
+    "description": "由独立项目维护的 Apple Music 音源插件，提供搜索、歌单、歌词与预览播放（完整音轨受 DRM 限制）。",
+    "repo": "MiaM1ku/qplayer-apple-plugin",
+    "publisherKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb20opVRUPIiFEeYdDli4uVbL1ry/+VVg5zHVC9/tN0rGcmcssS/Ko3mHjzairTmZZtIuWngooAvqOtOguaK/mg=="
   }
 ]

--- a/player-core/src/test/java/dev/t1m3/qplayer/plugin/PluginCatalogServiceTest.java
+++ b/player-core/src/test/java/dev/t1m3/qplayer/plugin/PluginCatalogServiceTest.java
@@ -33,7 +33,7 @@ public class PluginCatalogServiceTest {
 
     @Test public void pinnedSourcesCarryAValidIdAndPublisherKey() throws Exception {
         List<PluginCatalogService.Source> sources = PluginCatalogService.loadBundledSources();
-        assertEquals(6, sources.size());
+        assertEquals(7, sources.size());
         Set<String> ids = new HashSet<>();
         for (PluginCatalogService.Source source : sources) {
             dev.t1m3.qplayer.media.MediaId.validateProvider(source.id);
@@ -48,6 +48,7 @@ public class PluginCatalogServiceTest {
         assertTrue(ids.contains("migu"));
         assertTrue(ids.contains("kugou"));
         assertTrue(ids.contains("soda"));
+        assertTrue(ids.contains("apple"));
     }
 
     @Test public void latestReleaseFallsBackToTheNextCandidateAndPicksTheQplugAsset()


### PR DESCRIPTION
## 说明

向内置插件目录增加 [MiaM1ku/qplayer-apple-plugin](https://github.com/MiaM1ku/qplayer-apple-plugin)。

- 发布者公钥与酷我/咪咕/酷狗/汽水相同（`publisher-key.pub`）
- latest release：`v0.1.0`，挂载唯一 `apple-0.1.0.qplug`
- 完整音轨受 FairPlay DRM 限制，插件提供 catalog 搜索与官方预览流

`PluginCatalogServiceTest` 已同步条目数量。